### PR TITLE
fix: add missing closing brace to lib/i18n/de/intro.json

### DIFF
--- a/lib/i18n/de/intro.json
+++ b/lib/i18n/de/intro.json
@@ -26,3 +26,4 @@
     "next": "Weiter",
     "finish": "Fertig"
   }
+}


### PR DESCRIPTION
This PR fixes #50 `fix: Missing closing brace in lib/i18n/de/intro.json`

Add the missing '}' character in lib/i18n/de/intro.json,
fixing an invalid JSON structure and restoring proper parsing
of the German localization file.

